### PR TITLE
BUG: Remove redirect URL's ending double forward slashes.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
  <title>SimpleITK</title>
- <meta http-equiv="refresh" content="0; URL='http://simpleitk.org'" />
+ <meta http-equiv="refresh" content="0; URL=http://simpleitk.org" />
 </head>
 See <a href="http://simpleitk.org">SimpleITK Homepage</a>
 </html>


### PR DESCRIPTION
Remove the ending double forward slashes that show up in the browser after
redirecting:
http://www.simpleitk.org//

(or www.simpleitk.org// hiding the http:// part).